### PR TITLE
Added missing mode for photos section

### DIFF
--- a/resources/lib/plexbmc.py
+++ b/resources/lib/plexbmc.py
@@ -2878,6 +2878,7 @@ def amberskin():
                     sharedCount += 1
                     continue
                 window="Pictures"
+                mode=MODE_PHOTOS
                 WINDOW.setProperty("plexbmc.%d.year" % (sectionCount) , "ActivateWindow(%s,%s%s%s&mode=%s,return)" % (window, base_url, path, "/year", mode) )
                 
             else:


### PR DESCRIPTION
The addon crashed on Isengard when the user has the Mobile Photos section enabled. This was caused by not setting the mode value for the relevant section. This PR fixes that issue.